### PR TITLE
Navigate to next/previous change

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -149,16 +149,17 @@ function Doc:save(...)
 	old_doc_save(self, ...)
 	update_diff()
 end
+
 local function get_active_view()
-  if getmetatable(core.active_view) == DocView then
-    return core.active_view
-  end
-  return nil
+	if getmetatable(core.active_view) == DocView then
+		return core.active_view
+	end
+	return nil
 end
 
 local function jump_to_next_change()
 	local doc = get_active_view().doc
-  local line, col = doc:get_selection()
+	local line, col = doc:get_selection()
 
 	while current_diff[line] do
 		line = line + 1
@@ -175,7 +176,7 @@ end
 
 local function jump_to_previous_change()
 	local doc = get_active_view().doc
-  local line, col = doc:get_selection()
+	local line, col = doc:get_selection()
 
 	while current_diff[line] do
 		line = line - 1
@@ -191,12 +192,11 @@ local function jump_to_previous_change()
 end
 
 command.add("core.docview", {
-  ["gitdiff:previous-change"] = function()
-    jump_to_previous_change()
-  end,
+	["gitdiff:previous-change"] = function()
+		jump_to_previous_change()
+	end,
 
-  ["gitdiff:next-change"] = function()
-    jump_to_next_change()
-  end,
+	["gitdiff:next-change"] = function()
+		jump_to_next_change()
+	end,
 })
-

--- a/init.lua
+++ b/init.lua
@@ -4,6 +4,7 @@ local config = require "core.config"
 local DocView = require "core.docview"
 local Doc = require "core.doc"
 local common = require "core.common"
+local command = require "core.command"
 local style = require "core.style"
 local gitdiff = require "plugins.gitdiff_highlight.gitdiff"
 
@@ -148,3 +149,54 @@ function Doc:save(...)
 	old_doc_save(self, ...)
 	update_diff()
 end
+local function get_active_view()
+  if getmetatable(core.active_view) == DocView then
+    return core.active_view
+  end
+  return nil
+end
+
+local function jump_to_next_change()
+	local doc = get_active_view().doc
+  local line, col = doc:get_selection()
+
+	while current_diff[line] do
+		line = line + 1
+	end
+
+	while line < #doc.lines do
+		if current_diff[line] then
+			doc:set_selection(line, col, line, col)
+			return
+		end
+		line = line + 1
+	end
+end
+
+local function jump_to_previous_change()
+	local doc = get_active_view().doc
+  local line, col = doc:get_selection()
+
+	while current_diff[line] do
+		line = line - 1
+	end
+
+	while line > 0 do
+		if current_diff[line] then
+			doc:set_selection(line, col, line, col)
+			return
+		end
+		line = line - 1
+	end
+end
+
+command.add("core.docview", {
+  ["gitdiff:previous-change"] = function()
+    jump_to_previous_change()
+  end,
+
+  ["gitdiff:next-change"] = function()
+    jump_to_next_change()
+  end,
+})
+

--- a/init.lua
+++ b/init.lua
@@ -61,10 +61,10 @@ end
 
 local function set_doc(doc_name)
 	if current_diff ~= {} and current_file.name ~= nil then
-	diffs[current_file.name] = {
-		diff = current_diff,
-		is_in_repo = current_file.is_in_repo
-	}
+		diffs[current_file.name] = {
+			diff = current_diff,
+			is_in_repo = current_file.is_in_repo
+		}
 	end
 	current_file.name = doc_name
 	if diffs[current_file.name] ~= nil then
@@ -138,8 +138,8 @@ end
 
 local old_docview_update = DocView.update
 function DocView:update()
-	local filename = self.doc.abs_filename or ""
-	if current_file.name ~= filename and filename ~= "---" and core.active_view.doc == self.doc then
+	local filename = self.doc.abs_filename
+	if filename and current_file.name ~= filename and filename ~= "---" and #filename>0 and core.active_view.doc == self.doc then
 		set_doc(filename)
 	end
 	return old_docview_update(self)
@@ -150,15 +150,8 @@ function Doc:save(...)
 	update_diff()
 end
 
-local function get_active_view()
-	if getmetatable(core.active_view) == DocView then
-		return core.active_view
-	end
-	return nil
-end
-
 local function jump_to_next_change()
-	local doc = get_active_view().doc
+	local doc = core.active_view.doc
 	local line, col = doc:get_selection()
 
 	while current_diff[line] do
@@ -175,7 +168,7 @@ local function jump_to_next_change()
 end
 
 local function jump_to_previous_change()
-	local doc = get_active_view().doc
+	local doc = core.active_view.doc
 	local line, col = doc:get_selection()
 
 	while current_diff[line] do


### PR DESCRIPTION
This PR adds navigation commands for jumping to the next/previous change within a file. This is suitable for mapping to hotkeys, but no default keymap is provided.