### PR TITLE
Update init.lua

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -142,26 +142,21 @@ end
 local old_doc_save = Doc.save
 function Doc:save(...)
 	old_doc_save(self, ...)
-	core.add_thread(function()
-		update_diff(self)
+	core.add_thread(update_diff, nil, self)
 	end)
 end
 
 local old_docview_new = DocView.new
 function DocView:new(...)
 	old_docview_new(self, ...)
-	core.add_thread(function()
-		update_diff(self.doc)
-	end)
+	core.add_thread(update_diff, nil, self.doc)
 end
 
 local old_doc_load = Doc.load
 function Doc:load(...)
 	old_doc_load(self, ...)
 	self.gitdiff_highlight_last_doc_lines = #self.lines
-	core.add_thread(function()
-		update_diff(self)
-	end)
+	core.add_thread(update_diff, nil, self)
 end
 
 -- add minimap support only after all plugins are loaded
@@ -223,11 +218,6 @@ local function jump_to_previous_change()
 end
 
 command.add("core.docview", {
-	["gitdiff:previous-change"] = function()
-		jump_to_previous_change()
-	end,
-
-	["gitdiff:next-change"] = function()
-		jump_to_next_change()
-	end,
+	["gitdiff:previous-change"] = jump_to_previous_change,
+	["gitdiff:next-change"] = jump_to_next_change
 })

--- a/init.lua
+++ b/init.lua
@@ -42,14 +42,9 @@ local function gitdiff_padding(dv)
 end
 
 local function update_diff(doc)
-	if doc == nil or doc.filename == nil then return end
+	if not doc or not doc.abs_filename then return end
 
-	local finfo = system.get_file_info(doc.filename)
-	local full_path = finfo and system.absolute_path(doc.filename)
-	if not full_path then
-		return
-	end
-
+	local full_path = doc.abs_filename
 	core.log_quiet("[gitdiff_highlight] updating diff for " .. full_path)
 
 	local path = full_path:match("(.*" .. PATHSEP .. ")")
@@ -70,6 +65,7 @@ local function update_diff(doc)
 	end
 
 	local max_diff_size
+	local finfo = system.get_file_info(full_path)
 	max_diff_size = config.plugins.gitdiff_highlight.max_diff_size * finfo.size
 	local diff_proc = process.start({
 		"git", "-C", path, "diff", "HEAD", "--word-diff",

--- a/init.lua
+++ b/init.lua
@@ -117,8 +117,10 @@ function DocView:draw_line_gutter(line, x, y, width)
 end
 
 function DocView:get_gutter_width()
-	if not get_diff(self.doc).is_in_repo then return old_gutter_width(self) end
-	return old_gutter_width(self) + style.padding.x * style.gitdiff_width / 12
+	local gw, gpad = old_gutter_width(self)
+	if not get_diff(self.doc).is_in_repo then return gw, gpad end
+	
+	return gw + style.padding.x * style.gitdiff_width / 12, gpad
 end
 
 local old_text_change = Doc.on_text_change

--- a/init.lua
+++ b/init.lua
@@ -144,18 +144,11 @@ function Doc:on_text_change(type)
 	return on_text_change(self)
 end
 
-
 local old_doc_save = Doc.save
 function Doc:save(...)
 	old_doc_save(self, ...)
 	core.add_thread(update_diff, nil, self)
 	end)
-end
-
-local old_docview_new = DocView.new
-function DocView:new(...)
-	old_docview_new(self, ...)
-	core.add_thread(update_diff, nil, self.doc)
 end
 
 local old_doc_load = Doc.load


### PR DESCRIPTION
- now works on all files that are in a repository, not only the ones in project root directory
- doesn't force minimap on users that have disabled it
- some other minor cleanups

basically implementing suggestion of https://github.com/vincens2005/lite-xl-gitdiff-highlight/issues/4#issuecomment-990606677

fixes #3
fixes #4
where it was confusing that nothing was highlighted, unless project root was also the repo of any given file, and users went down rabbit-holes to find reason on their end