### PR TITLE
better hunk header detection

### DIFF
--- a/gitdiff.lua
+++ b/gitdiff.lua
@@ -29,7 +29,7 @@ end
 
 -- this will only work on single-file diffs
 function gitdiff.changed_lines(diff)
-	if diff == nil then return {} end
+	if not diff then return {} end
 	local changed_lines = {}
 	local hunks = extract_hunks(diff)
 	-- iterate over hunks
@@ -37,7 +37,7 @@ function gitdiff.changed_lines(diff)
 		local current_line
 		local hunk_start = hunk[1]:match("@@%s+-%d+,%d+%s++(%d-),%d+%s+@@")
 		hunk_start = tonumber(hunk_start)
-		if  hunk_start == nil then -- mod
+		if not hunk_start then -- mod
 			goto continue
 		end
 

--- a/gitdiff.lua
+++ b/gitdiff.lua
@@ -9,7 +9,7 @@ local function extract_hunks(input)
 	local function end_hunk(new_line)
 		if #current_hunk > 0 then
 			table.insert(hunks, current_hunk)
-			current_hunk = {new_line}
+			current_hunk = { new_line }
 		end
 	end
 
@@ -33,7 +33,7 @@ function gitdiff.changed_lines(diff)
 	local changed_lines = {}
 	local hunks = extract_hunks(diff)
 	-- iterate over hunks
-	for _, hunk in pairs(hunks) do
+	for _, hunk in ipairs(hunks) do
 		local current_line
 		local hunk_start = hunk[1]:match("@@%s+-%d+,%d+%s++(%d-),%d+%s+@@")
 		hunk_start = tonumber(hunk_start)
@@ -46,7 +46,7 @@ function gitdiff.changed_lines(diff)
 		-- remove hunk header
 		hunk[1] = hunk[1]:gsub("@@%s+-%d+,%d+%s++%d+,%d+%s+@@", "")
 
-		for _, line in pairs(hunk) do
+		for _, line in ipairs(hunk) do
 			if line:match("^%s-%[%-.-%-]$") then
 				table.insert(changed_lines, {
 					line_number = current_line,
@@ -76,7 +76,7 @@ function gitdiff.changed_lines(diff)
 	end
 
 	local indexed_changed_lines = {}
-	for _, line in pairs(changed_lines) do
+	for _, line in ipairs(changed_lines) do
 		indexed_changed_lines[line.line_number] = line.change_type
 	end
 


### PR DESCRIPTION
I ran into a diff with this format and gitdiff failed:
```
diff --git a/first.txt b/first.txt
index 445a69c..a538df6 100644
--- a/first.txt
+++ b/first.txt
@@ -1 +1,2 @@
[-hahaha-]{+hahaha12+}
```
while I added a fix, I also did some cosmetics.

consider pulling in my changes or some of them, thanks.